### PR TITLE
review/chandan kumar/bump octavia

### DIFF
--- a/zuul.d/integration-pipeline-train-centos7.yaml
+++ b/zuul.d/integration-pipeline-train-centos7.yaml
@@ -62,9 +62,6 @@
         - periodic-tripleo-ci-centos-7-scenario007-standalone-train:
             dependencies:
               - periodic-tripleo-centos-7-train-containers-build-push
-        - periodic-tripleo-ci-centos-7-scenario010-standalone-train:
-            dependencies:
-              - periodic-tripleo-centos-7-train-containers-build-push
         - periodic-tripleo-ci-centos-7-standalone-upgrade-train:
             dependencies:
               - periodic-tripleo-centos-7-train-containers-build-push

--- a/zuul.d/standalone-jobs.yaml
+++ b/zuul.d/standalone-jobs.yaml
@@ -187,23 +187,6 @@
         tempest_private_net_provider_type: 'vxlan'
         use_os_tempest: true
 
-- job:
-    name: periodic-tripleo-ci-centos-7-scenario010-standalone-master
-    parent: tripleo-ci-base-standalone-periodic
-    vars: &scen10_standalone_vars
-      tags:
-        - build
-        - standalone
-        - octavia
-      featureset: '062'
-      release: master
-      standalone_ceph: true
-      featureset_override:
-        standalone_environment_files:
-          - 'environments/low-memory-usage.yaml'
-          - 'environments/services/octavia.yaml'
-          - 'ci/environments/scenario010-standalone.yaml'
-
 ### CentOS-8 Jobs
 - job:
     name: periodic-tripleo-ci-centos-8-standalone-master
@@ -653,14 +636,6 @@
       branch_override: "stable/train"
       release: train
 
-- job:
-    name: periodic-tripleo-ci-centos-7-scenario010-standalone-train
-    parent: periodic-tripleo-ci-centos-7-scenario010-standalone-master
-    override-checkout: "stable/train"
-    vars:
-      branch_override: "stable/train"
-      release: train
-
 ### stable/stein standalone jobs ###
 - job:
     name: periodic-tripleo-ci-centos-7-standalone-stein
@@ -790,24 +765,6 @@
           'share.capability_snapshot_support': 'False'
           'share.capability_create_share_from_snapshot_support': 'False'
         test_white_regex: ''
-
-- job:
-    name: periodic-tripleo-ci-centos-7-scenario010-standalone-stein
-    parent: tripleo-ci-base-standalone-periodic
-    override-checkout: "stable/stein"
-    vars:
-      featureset: '052'
-      branch_override: "stable/stein"
-      release: stein
-      standalone_ceph: true
-      featureset_override:
-        standalone_container_cli: docker
-        run_tempest: false
-        standalone_environment_files:
-          - 'environments/low-memory-usage.yaml'
-          - 'environments/services/octavia.yaml'
-          - 'ci/environments/scenario010-standalone.yaml'
-        use_os_tempest: false
 
 # RDO jobs for check pipeline - for scenario standalones yaml anchors let us
 # avoid duplication https://tree.taiga.io/project/tripleo-ci-board/us/1228


### PR DESCRIPTION
- Fix undercloud-containers consumer job
- Use single playbook for multinode jobs
- Add undercloud fs050 upgrades to master/v/u periodic
- Remove usage of standalone_container_ceph_updates
- Remove reference of vexxhost nodesets
- Remove vexxhost nodeset from other jobs
- Remove RHEL-8 jobs
- Change rdo nodeset labels to vexxhost
- Enure multinode ipa job uses two nodes on vexxhost
- Temporary exception of os-net-config
- Remove rhel-8 nodesets
- Ensure ansible is installed
- Switch rdopkg-reqcheck job to a Fedora 32 node
- base: use prepare-workspace-openshift when connection is kubectl
- base: disable mirror for kubectl connection
- Move podman-fedora-31 jobs to Fedora 32
- Remove prepare-workspace-openshift role from base/pre.yaml
- Remove podman-package-fedora-31 job
- Remove vexxhost leftovers from templates
- Adds tripleo component standalone-upgrade-master/victoria/ussuri
- Switch rdopkg-reqcheck to use a container-based nodeset
- Temporary set Http.sslVerify to false
- Add explicit docker-ha and podman for ussuri component upgrade job
- Add fedora 32 and 33 vexxhost node
- Use fedora rawhide nodeset from vexxhost
- Hack for https://review.rdoproject.org/r/31434
- Add missing job for Train buildsys tags update
- Update CentOS8 repo names
- Add override-checkout in c7 train jobs
- Add c8 branch jobs for c8stream dependency line
- Temporary downgrade selinux-policy in weirdo-periodic
- Add periodic victoria cloudsig job
- Revert "Hack for https://review.rdoproject.org/r/31434"
- Add upstream-centos-{7,8,8-stream]-psi-public nodesets
- Improve package detection in rpm-packaging jobs
- Revert "Temporary downgrade selinux-policy in weirdo-periodic"
- Add weirdo cloudsig periodic jobs
- Add weirdo cloudsig periodic jobs to template
- Use centos8-stream mock config for master rpmbuild jobs
- Switch default ansible-version to 2.9
- Fix missing quote in rpmbuild-rpm-packaging job
- Run centos 8 streamdeps jobs on centos 8 stream nodes
- Add job for component validations
- Trigger jobs on wallaby stream tags update
- Add periodic jobs to test wallaby with centos8-stream
- Remove periodic-victoria-centos-stream template
- Update periodic scenario004 job
- Add weirdo jobs for Victoria on stream tags update
- Add victoria OVB check jobs
- Use tempestconf overrides from fs itself
- Revert "Use tempestconf overrides from fs itself"
- Adding tempestconf_profile_overrides for sc10-ovn
- Add validations jobs per components to the components pipeline
- Added initial jobs for container build dependency pipeline
- Add support for test nfvinfo in validate-buildsys-tags
- Adapt ooo rdoinfo gate jobs for nfvinfo
- Run Cloud SIG periodic tripleo job with force_non_periodic
- Add support for nfvinfo in weirdo-buildsys-tags jobs
- Add openvswitch dependency pipeline standalone definition
- Add master-release ooo job to validate nfvinfo
- Add weirdo jobs for Ussuri on stream tags update
- Apply same config for periodic jobs as in upstream
- Switch target to centos8-stream for pending releases
- Add weirdo jobs for Train on stream tags update
- Use centos-8-stream nodes for rpmbuild jobs
- Remove pin for ubi8 image
- Add more ooo jobs for nfvinfo tags update
- Add control-vip/update tempest conf: c7 sc04 train
- Add podman-package-fedora-33 job
- Added container tools dependency jobs to dependency pipeline
- Add tripleo-podman-integration-centos-8-standalone to pipeline
- Remove fedora 32 podman jobs
- Replace podman sc000 to plain standalone
- Fix typo in registry
- Add jobs to validate CBS builds for CentOS Stream 8
- Add CentOS-8 train branchful check jobs
- Update pip to latest in rdo-tox-molecule
- Adding c8-stream nodesets for tripleo-ovb-centos-8-stream-primary-vexxhost, two-centos-8-stream-nodes-vexxhost
- Temporary use unpublished rdo-release rpm for c8-stream
- Revert "Temporary use unpublished rdo-release rpm for c8-stream"
- Moving master Integration line to centos 8 stream repo content
- Removing volume_mounts from var in container push
- Moving victoria Integration line to centos 8 stream repo content
- Moving ussuri Integration line to centos 8 stream repo content
- fs050 is standalone-upgrade, dup job remove
- Moving train Integration line to centos 8 stream repo content
- Add a log file with the list of tested deps updates in weirdo jobs
- Detect nfv tag based on changed_repos
- add standalone-undercloud-upgrade
- Add log file with list of tested deps in oooq jobs
- Remove /p from git URL in review.rdoproject.org
- Use stream labels on all centos 8 nodesets
- Removing c8 stream specific nodesets from integration lines
- Remove centos-8-stream pipeline jobs
- Add branch-level container-tools dep jobs
- Removing c8 stream specific nodesets
- Added missing ceph-ansible victoria jobs
- Use CS8 in DLRN-build-tripleo-centos8 for master and wallaby
- Removing tripleo_image_source from integration lines
- Add wallaby promotion jobs
- Mini integration pipeline for wallaby
- Run only Octavia smoke tests in periodic scenario010 job
- Add wallaby component standalone jobs
- Fix component standalone job names
- Add wallaby SC001 standalone component jobs
- Add wallaby SC002 standalone component jobs
- Add wallaby SC003 and SC004 standalone component jobs
- Add wallaby scenario standalone component jobs
- Add wallaby component jobs
- Add wallaby multinode component jobs
- Use CloudSIG repos to gate promotions to wallaby-testing
- [wallaby] full integration pipeline
- Add weirdo jobs to gate wallaby-release updates
- Switch back to rdoproject.repos for wallaby release rpm
- Drop sc10 c7 job from train integration line
