### PR TITLE
Add networker to edpm_nodes_ips

### DIFF
--- a/zuul.d/_data_plane_adoption.yaml
+++ b/zuul.d/_data_plane_adoption.yaml
@@ -134,6 +134,8 @@
       edpm_node_ips:
         - 192.168.122.106
         - 192.168.122.107
+        - 192.168.122.108
+        - 192.168.122.109
     host-vars:
       undercloud:
         address_suffix: 100


### PR DESCRIPTION
Add networker to edpm_nodes_ips for
adoption-multinode-networker-to-crc