### PR TITLE
Insert ping test related variables for adoption.

### DIFF
--- a/playbooks/data_plane_adoption/deploy_tripleo_run_repo_tests.yaml
+++ b/playbooks/data_plane_adoption/deploy_tripleo_run_repo_tests.yaml
@@ -445,6 +445,18 @@
         - edpm_container_registry_logins is defined
         - edpm_container_registry_logins is mapping
 
+    - name: Insert ping test related variables
+      when: ping_test | default(false) | bool
+      ansible.builtin.blockinfile:
+        marker_begin: "BEGIN ping test related vars"
+        marker_end: "END ping test related vars"
+        path: "{{ rdo_dir }}/vars.yaml"
+        block: |
+          ping_test: true
+          prelaunch_test_instance: true
+          ping_test_loss_threshold: {{ ping_test_loss_threshold | default(0) }}
+          ping_test_loss_threshold_percent: {{ ping_test_loss_threshold_percent | default(0) }}
+
     - name: Fetch hash and set ci_testing_hash fact for periodic
       when: "'periodic' in zuul.job or (force_periodic|default(false)|bool)"
       block:


### PR DESCRIPTION
When `ping_test` is set to `true` in the job we collect all relevant
threshold variables. We also ensure that `prelaunch_test_instance` is
set to `true` as well as it's a requirement for the ping test to work.